### PR TITLE
⚡ Bolt: Optimize FontAwesome imports for tree-shaking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2026-06-16 - Tree-shaking FontAwesome icons
+
+**Aprendizado:** O uso de imports globais para bibliotecas de ícones como FontAwesome (`fas`, `fab`, `far`) impede o tree-shaking, resultando em bundles extremamente grandes (2MB+ no caso deste projeto). Importar ícones individualmente permite que o bundler remova milhares de ícones não utilizados.
+
+**Aplicação futura:** Sempre verificar `main.js` ou arquivos de configuração de ícones em projetos Vue/React. Substituir imports de "sets" inteiros por ícones específicos. No Vite, o ganho de performance no carregamento inicial (LCP) é drástico e mensurável através do comando `npm run build`.

--- a/src/main.js
+++ b/src/main.js
@@ -5,19 +5,37 @@ import App from './App.vue'
 import router from './router.js'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { fas } from '@fortawesome/free-solid-svg-icons'
-import { far } from '@fortawesome/free-regular-svg-icons'
-import { fab } from '@fortawesome/free-brands-svg-icons'
-import { faWindowClose } from '@fortawesome/free-solid-svg-icons'
+import {
+  faWindowClose,
+  faAngleDown,
+  faAngleUp,
+  faGraduationCap,
+  faBriefcase,
+  faHandshake,
+  faRobot
+} from '@fortawesome/free-solid-svg-icons'
+import {
+  faGithub,
+  faGitlab,
+  faLinkedin
+} from '@fortawesome/free-brands-svg-icons'
 import i18n from "./i18n";
 
 
 import 'flowbite';
 // import { ValidationProvider } from 'vee-validate';
-library.add(faWindowClose)
-library.add(fas)
-library.add(far)
-library.add(fab)
+library.add(
+  faWindowClose,
+  faAngleDown,
+  faAngleUp,
+  faGraduationCap,
+  faBriefcase,
+  faHandshake,
+  faRobot,
+  faGithub,
+  faGitlab,
+  faLinkedin
+)
 
 const app = createApp(App)
 app.component('font-awesome-icon', FontAwesomeIcon)


### PR DESCRIPTION
I have optimized the FontAwesome icon imports in the `src/main.js` file. Previously, the application was importing entire icon sets (`fas`, `far`, `fab`), which significantly bloated the production bundle because thousands of unused SVG icons were being included.

By switching to individual icon imports for the specific icons used in the project, I've enabled effective tree-shaking.

**Performance Impact:**
- **Before:** `dist/assets/index-C0Qb0saP.js` was **2,022.52 kB** (gzip: 702.13 kB).
- **After:** `dist/assets/index-lC8B81hl.js` is **443.49 kB** (gzip: 144.35 kB).
- **Total reduction:** **~1.58 MB (~78%)**.

I have verified that all icons (social icons, project category icons, and UI toggles) continue to render correctly by running the application and using a Playwright script to capture screenshots of the home and projects pages. Unit tests and linting also pass.

---
*PR created automatically by Jules for task [3438074781817953612](https://jules.google.com/task/3438074781817953612) started by @thomasgroch*