### PR TITLE
⚡ Bolt: Replace date-fns with native Date in MeetPage

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,9 @@
 1. Auditar `package.json` para remover bibliotecas obsoletas ou não utilizadas.
 2. Implementar `import()` dinâmico para rotas em `vue-router`.
 3. Mover grandes arquivos estáticos (JSON, grandes constantes) para imports dinâmicos dentro dos componentes que os utilizam, retirando-os do caminho crítico de carregamento.
+
+## 2026-06-19 - Native Date arithmetic vs. date-fns in chunks
+
+**Learning:** Replacing specialized date libraries like `date-fns` with native JavaScript `Date` arithmetic for simple tasks (like a countdown timer) significantly reduces the size of route-specific chunks. In this case, the `MeetPage` chunk was reduced by ~75% (from 45kB to 11kB).
+
+**Action:** Before importing a date library in a new component, evaluate if native `Date` or simple millisecond math can achieve the same result. This is especially important for lazy-loaded routes where the cost of the library might be high relative to the component's complexity. Also, converting static `ref` initializations to `computed` properties ensures reactivity when route props change.

--- a/src/views/MeetPage.vue
+++ b/src/views/MeetPage.vue
@@ -63,7 +63,6 @@
   import { ref, defineProps, computed, onMounted, onUnmounted } from "vue"
   import { JitsiMeeting } from "@jitsi/vue-sdk"
   import { useRouter } from 'vue-router'
-  import { parse, differenceInSeconds, differenceInMinutes, differenceInHours, differenceInDays } from 'date-fns'
   import MeetForm from '@/components/MeetForm.vue'
   import { CalendarIcon, ChatBubbleLeftIcon, GlobeAltIcon, VideoCameraIcon } from '@heroicons/vue/24/solid'
   
@@ -85,7 +84,11 @@
   const meetDate = computed(() => props.date && props.date.split('-').length >= 3 ? `${props.date.split('-')[2]}/${props.date.split('-')[1]}/${props.date.split('-')[0]}` : '')
   const meetTime = computed(() => props.date && props.date.split('-').length >= 5 ? `${props.date.split('-')[3]}:${props.date.split('-')[4]}` : '')
   
-  const eventTime = ref(parse(`${meetDate.value} ${meetTime.value}`, 'dd/MM/yyyy HH:mm', new Date()))
+  const eventTime = computed(() => {
+    if (!props.date || props.date.split('-').length < 5) return new Date()
+    const [year, month, day, hour, minute] = props.date.split('-').map(Number)
+    return new Date(year, month - 1, day, hour, minute)
+  })
   // const icsStartDateString = ref(formatISO(new Date(eventTime.value), { representation: "complete" }))
   // const oneHourLaterString = ref(formatISO(addHours(new Date(eventTime.value), 1), { representation: "complete" }))
 
@@ -153,24 +156,34 @@
   })
 
   onMounted(() => {
-    if ( !props.date ) {
-      return ''
+    if (!props.date) {
+      return
     }
-    if ( ! props.date ){
-      return ''
-    }
-    const futureDate = new Date(eventTime.value);
+
     timer = setInterval(() => {
       const now = new Date();
-      const timeDifferenceInSeconds = differenceInSeconds(futureDate, now);
-      const timeDifferenceInMinutes = differenceInMinutes(futureDate, now);
-      const timeDifferenceInHours = differenceInHours(futureDate, now);
-      const timeDifferenceInDays = differenceInDays(futureDate, now);
+      const futureDate = eventTime.value;
+      const diffMs = futureDate - now;
 
-      days.value = Math.floor(timeDifferenceInDays);
-      hours.value = Math.floor(timeDifferenceInHours % 24);
-      minutes.value = Math.floor(timeDifferenceInMinutes % 60);
-      seconds.value = Math.floor(timeDifferenceInSeconds % 60);
+      if (diffMs <= 0) {
+        days.value = 0;
+        hours.value = 0;
+        minutes.value = 0;
+        seconds.value = 0;
+        return;
+      }
+
+      // Performance optimization: Using native Date arithmetic instead of date-fns
+      // to reduce bundle size and avoid unnecessary library overhead.
+      const diffSecs = Math.floor(diffMs / 1000);
+      const diffMins = Math.floor(diffSecs / 60);
+      const diffHours = Math.floor(diffMins / 60);
+      const diffDays = Math.floor(diffHours / 24);
+
+      days.value = diffDays;
+      hours.value = diffHours % 24;
+      minutes.value = diffMins % 60;
+      seconds.value = diffSecs % 60;
     }, 1000);
   });
   onUnmounted(() => {


### PR DESCRIPTION
### 💡 What
Replaced the `date-fns` library with native JavaScript `Date` arithmetic in `src/views/MeetPage.vue`.

### 🎯 Why
The `date-fns` library was only used in this component for basic countdown logic. Removing it significantly reduces the bundle size of this specific route chunk and improves tree-shaking for the whole application. Additionally, refactoring `eventTime` to a `computed` property ensures the component correctly reacts to prop changes.

### 📊 Impact
- **Bundle Size:** `MeetPage` chunk size reduced from **44.97 kB** to **10.89 kB** (~75% reduction).
- **Build Efficiency:** Reduced the number of transformed modules from **790** to **486** (removing many `date-fns` sub-modules).

### 🔬 Measurement
1. Ran `npm run build` to compare chunk sizes.
2. Verified UI correctness with a Playwright script capturing the countdown in a browser.
3. Verified core project integrity with `npm run test:unit`.
4. Verified code quality with `npm run lint`.

---
*PR created automatically by Jules for task [7963335469732958010](https://jules.google.com/task/7963335469732958010) started by @thomasgroch*