### PR TITLE
⚡ Bolt: lazy-load resume.json to reduce main bundle size

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,9 @@
 1. Auditar `package.json` para remover bibliotecas obsoletas ou não utilizadas.
 2. Implementar `import()` dinâmico para rotas em `vue-router`.
 3. Mover grandes arquivos estáticos (JSON, grandes constantes) para imports dinâmicos dentro dos componentes que os utilizam, retirando-os do caminho crítico de carregamento.
+
+## 2026-06-30 - Otimização de bundle via Dynamic Import de Resume JSON
+
+**Aprendizado:** Arquivos JSON estáticos importados em múltiplos componentes (como `resume.json`) são incluídos no bundle principal. Transformá-los em `import()` dinâmico permite que o Vite os separe em chunks independentes, reduzindo o tamanho do `index.js`.
+
+**Aplicação futura:** Identificar arquivos de dados (JSON, grandes objetos de configuração) que não são necessários para a renderização inicial crítica e convertê-los para carregamento assíncrono nos hooks `onMounted` ou `created`.

--- a/src/components/CardProfile.vue
+++ b/src/components/CardProfile.vue
@@ -1,7 +1,12 @@
 <script setup>
 import Logo from '@/components/Logo.vue'
-import {ref} from 'vue'
-import resume from "~/resume.json"
+import {ref, onMounted} from 'vue'
+
+const resume = ref(null)
+
+onMounted(async () => {
+  resume.value = (await import('~/resume.json')).default
+})
 
 const open = ref(false)
 
@@ -20,7 +25,7 @@ defineOptions({
     <p class="py-1 text-neutral-500">{{ $t('general.role_profile') }}, <span
       class="dark:bg-neutral-700 bg-green-100 text-green-400 rounded px-1 font-normal">Web Developer</span></p>
 
-    <div class="py-5 flex space-x-3 justify-center text-sm text-center px-5">
+    <div class="py-5 flex space-x-3 justify-center text-sm text-center px-5" v-if="resume">
       <a class="dark:hover:bg-transparent px-2" v-for="n in resume.basics.profiles" :href="n.url" target="_blank">
         <font-awesome-icon :icon="['fab', n.network]"
                            class="fa-2x text-neutral-500 hover:text-green-300 dark:bg-transparent px" />

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="py-16">
     <div class="py-5 flex space-x-3 justify-center text-sm text-center px-5"
-        v-if="currentPath != '/'">
+        v-if="currentPath != '/' && resume">
       <a class="dark:hover:bg-transparent px-2" v-for="n in resume.basics.profiles" :href="n.url" target="_blank">
         <font-awesome-icon :icon="['fab', n.network]"
                            class="fa-2x text-neutral-500 hover:text-green-300 dark:bg-transparent px" />
@@ -43,11 +43,17 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
-import resume from "~/resume.json";
+
 const route = useRoute();
 const currentPath = computed(() =>route.path)
+const resume = ref(null)
+
+onMounted(async () => {
+  resume.value = (await import('~/resume.json')).default
+})
+
 import { useI18n } from "vue3-i18n";
 const i18n = useI18n();
 const setLocale = (lang) => {

--- a/src/views/ProjectPage.vue
+++ b/src/views/ProjectPage.vue
@@ -13,8 +13,6 @@ import ProjectCard from '@/components/ProjectCard.vue'
 </template>
 
 <script>
-import resume from "~/resume.json";
-
 export default {
   name: "ProjectPage",
   metaInfo: {
@@ -22,8 +20,12 @@ export default {
   },
   data() {
     return {
-      projects: resume.work
+      projects: []
     }
+  },
+  async created() {
+    const resume = (await import('~/resume.json')).default
+    this.projects = resume.work
   },
   components: {
     ProjectCard,

--- a/src/views/StackPage.vue
+++ b/src/views/StackPage.vue
@@ -27,8 +27,6 @@ import StackList from '@/components/StackList.vue'
 </template>
 
 <script>
-import resume from "~/resume.json";
-
 export default {
   name: "StackPage",
   metaInfo: {
@@ -36,8 +34,12 @@ export default {
   },
   data() {
     return {
-      stacks: resume.stack
+      stacks: {}
     }
+  },
+  async created() {
+    const resume = (await import('~/resume.json')).default
+    this.stacks = resume.stack
   }
 }
 </script>


### PR DESCRIPTION
### ⚡ Bolt: Lazy-load resume.json

💡 **What:**
Converted the static import of `resume.json` (a ~13KB asset) into dynamic `import()` calls across four key components: `CardProfile.vue`, `Footer.vue`, `ProjectPage.vue`, and `StackPage.vue`.

🎯 **Why:**
Static imports in Vite/Rollup cause the imported module to be bundled into the chunk that imports it. Since `resume.json` was imported in the main bundle (via Footer and CardProfile), it was bloating the initial payload. Lazy-loading it moves it to a separate chunk that is fetched asynchronously.

📊 **Impact:**
Reduces the main bundle (`index.js`) size from **274.66 kB** to **266.23 kB** (~8.43 kB reduction in raw size, ~3 kB gzipped). This improves initial load performance and Time to Interactive (TTI).

🔬 **Measurement:**
- Run `npm run build` and compare the size of `dist/assets/index-*.js`.
- Verified UI correctness via Playwright screenshots of Home, Projects, and Stack pages.
- Verified that `resume-*.js` is now a separate chunk in the `dist/assets` directory.

---
*PR created automatically by Jules for task [7558487534130394501](https://jules.google.com/task/7558487534130394501) started by @thomasgroch*